### PR TITLE
LTR-56 - Merge adding intial sequence for batch database dump and new …

### DIFF
--- a/looter/Taskfile.yml
+++ b/looter/Taskfile.yml
@@ -119,6 +119,16 @@ tasks:
         (docker compose exec -T staging-db mysql -uroot -p"$LOOTER_STAGING_DB_ROOT_PASSWORD" $LOOTER_STAGING_DB_NAME < /mnt/securedata/looter/staging/dumps/staging_db_structure_dump.sql 2>&1) && \
         echo "✅ Import completed with success !"
 
+  staging-db:export:
+    desc: Export staging_db database into dump file
+    cmds:
+      - echo "Exporting staging_db database into staging_db_data_dump.sql..."
+      - |
+        source .env && \
+        echo "🔄 Starting export... " && \
+        (docker compose exec -T staging-db mysqldump --databases $LOOTER_STAGING_DB_NAME -uroot -p"$LOOTER_STAGING_DB_ROOT_PASSWORD" > ./staging_db_data_dump.sql 2>/dev/null) && \
+        echo "✅ Export completed with success into ./staging_db_data_dump.sql !"
+
   # Scheduler
   scheduler:
     desc: Show scheduled jobs and their periodicity

--- a/looter/scrap_db_structure_dump.sql
+++ b/looter/scrap_db_structure_dump.sql
@@ -113,6 +113,24 @@ CREATE TABLE
     UNIQUE KEY `UNIQUE_KEY_UN` (`UNIQUE_KEY`)
   ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;
 
+INSERT INTO
+  `BATCH_JOB_EXECUTION_SEQ` (`ID`, `UNIQUE_KEY`)
+select
+  *
+from
+  (
+    select
+      0 as ID,
+      '0' as `UNIQUE_KEY`
+  ) as tmp
+where
+  not exists (
+    select
+      *
+    from
+      `BATCH_JOB_EXECUTION_SEQ`
+  );
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -151,6 +169,24 @@ CREATE TABLE
     `UNIQUE_KEY` char(1) NOT NULL,
     UNIQUE KEY `UNIQUE_KEY_UN` (`UNIQUE_KEY`)
   ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;
+
+INSERT INTO
+  `BATCH_JOB_SEQ` (`ID`, `UNIQUE_KEY`)
+select
+  *
+from
+  (
+    select
+      0 as ID,
+      '0' as `UNIQUE_KEY`
+  ) as tmp
+where
+  not exists (
+    select
+      *
+    from
+      `BATCH_JOB_SEQ`
+  );
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -226,6 +262,24 @@ CREATE TABLE
     `UNIQUE_KEY` char(1) NOT NULL,
     UNIQUE KEY `UNIQUE_KEY_UN` (`UNIQUE_KEY`)
   ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci;
+
+INSERT INTO
+  `BATCH_STEP_EXECUTION_SEQ` (`ID`, `UNIQUE_KEY`)
+select
+  *
+from
+  (
+    select
+      0 as ID,
+      '0' as `UNIQUE_KEY`
+  ) as tmp
+where
+  not exists (
+    select
+      *
+    from
+      `BATCH_STEP_EXECUTION_SEQ`
+  );
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
…export command

## 🛠️ Description

Adding intial sequence for batch database dump and new export command.

- Improving security or automation

Related ticket: [LTR-56](https://sleeved.atlassian.net/browse/LTR-56)

## 🔍 Context & Motivation

<!-- (Optional) Why is this change necessary? What problem does it solve? -->

## 📸 Screenshots / Terminal Output

<!-- (Optional) Logs, screenshots, config output, or a link to a test/demo environment -->

## ✅ Checklist

- [x] Infrastructure setup validated (e.g. services up & running)
- [x] Secrets/configs handled securely
- [x] Docker/Caddy syntax validated
- [x] Relevant documentation updated (`README`, `Taskfile`, etc.)
- [x] Project conventions followed (naming, structure, volumes, etc.)

## 🧠 Notes for Reviewers

<!-- Add important context, blockers, or anything worth highlighting -->


[LTR-56]: https://sleeved.atlassian.net/browse/LTR-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ